### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/890/438/043/890438043.geojson
+++ b/data/890/438/043/890438043.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"MS",
     "wof:created":1469052177,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0522baaeae08a869e14694ff21bc051",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":890438043,
-    "wof:lastmodified":1566612040,
+    "wof:lastmodified":1582312419,
     "wof:name":"Salem",
     "wof:parent_id":85674921,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.