### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/110/896/081/3/1108960813.geojson
+++ b/data/110/896/081/3/1108960813.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0628\u0644\u064a\u0645\u0648\u062b"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0644\u064a\u0645\u0648\u062b"
+    ],
     "name:ast_x_preferred":[
         "Plymouth"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u043b\u0456\u043c\u0443\u0442"
+    ],
+    "name:bel_x_variant":[
+        "\u041f\u043b\u0456\u043c\u0443\u0442"
     ],
     "name:bos_x_preferred":[
         "Plymouth"
@@ -79,6 +85,9 @@
     "name:fra_x_preferred":[
         "Plymouth"
     ],
+    "name:gle_x_preferred":[
+        "Plymouth"
+    ],
     "name:glg_x_preferred":[
         "Plymouth"
     ],
@@ -112,11 +121,17 @@
     "name:lav_x_preferred":[
         "Plimuta"
     ],
+    "name:lij_x_preferred":[
+        "Plymouth"
+    ],
     "name:lit_x_preferred":[
         "Plimutas"
     ],
     "name:lmo_x_preferred":[
         "Plymouth"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041f\u043b\u0438\u043c\u0443\u0442"
     ],
     "name:msa_x_preferred":[
         "Plymouth"
@@ -166,6 +181,9 @@
     "name:spa_x_preferred":[
         "Plymouth"
     ],
+    "name:srd_x_preferred":[
+        "Plymouth"
+    ],
     "name:srp_x_preferred":[
         "\u041f\u043b\u0438\u043c\u0443\u0442"
     ],
@@ -192,6 +210,9 @@
     ],
     "name:war_x_preferred":[
         "Plymouth"
+    ],
+    "name:wuu_x_preferred":[
+        "\u666e\u5229\u8305\u65af"
     ],
     "name:yor_x_preferred":[
         "Plymouth"
@@ -226,7 +247,7 @@
         }
     ],
     "wof:id":1108960813,
-    "wof:lastmodified":1566612038,
+    "wof:lastmodified":1690846213,
     "wof:name":"Plymouth",
     "wof:parent_id":85674911,
     "wof:placetype":"locality",

--- a/data/112/577/819/7/1125778197.geojson
+++ b/data/112/577/819/7/1125778197.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u0627\u062f\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u0627\u062f\u0633"
+    ],
     "name:ast_x_preferred":[
         "Brades"
     ],
@@ -76,6 +79,9 @@
     "name:fra_x_preferred":[
         "Brades"
     ],
+    "name:gle_x_preferred":[
+        "Brades"
+    ],
     "name:glg_x_preferred":[
         "Brades"
     ],
@@ -99,6 +105,9 @@
     ],
     "name:kor_x_preferred":[
         "\ube0c\ub808\uc774\uc988"
+    ],
+    "name:lav_x_preferred":[
+        "Breidisa"
     ],
     "name:lit_x_preferred":[
         "Breidsas"
@@ -227,7 +236,7 @@
         }
     ],
     "wof:id":1125778197,
-    "wof:lastmodified":1566612041,
+    "wof:lastmodified":1690846214,
     "wof:name":"Brades",
     "wof:parent_id":85674921,
     "wof:placetype":"locality",

--- a/data/856/749/21/85674921.geojson
+++ b/data/856/749/21/85674921.geojson
@@ -73,6 +73,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09a8\u09cd\u09a4 \u09aa\u09bf\u09a4\u09b0"
     ],
+    "name:ben_x_variant":[
+        "\u09aa\u09cd\u09b0\u09c7\u09b0\u09bf\u09a4 \u09aa\u09bf\u09a4\u09b0"
+    ],
     "name:bod_x_preferred":[
         "\u0f54\u0f7a\u0f0b\u0f4f\u0fb2\u0f7c\u0f0d"
     ],
@@ -100,17 +103,29 @@
     "name:ces_x_preferred":[
         "Petr"
     ],
+    "name:ces_x_variant":[
+        "svat\u00fd Petr"
+    ],
     "name:ckb_x_preferred":[
         "\u067e\u06ce\u062a\u0631\u06c6\u0633"
     ],
+    "name:cor_x_preferred":[
+        "Peder"
+    ],
     "name:cym_x_preferred":[
         "Sant Pedr"
+    ],
+    "name:cym_x_variant":[
+        "Pedr"
     ],
     "name:dan_x_preferred":[
         "Apostlen Peter"
     ],
     "name:deu_x_preferred":[
         "Simon Petrus"
+    ],
+    "name:deu_x_variant":[
+        "Petrus"
     ],
     "name:diq_x_preferred":[
         "Petrus"
@@ -128,6 +143,9 @@
     ],
     "name:epo_x_preferred":[
         "Sankta Petro"
+    ],
+    "name:epo_x_variant":[
+        "Simono Petro"
     ],
     "name:est_x_preferred":[
         "Peetrus"
@@ -165,14 +183,23 @@
     "name:heb_x_preferred":[
         "\u05e4\u05d8\u05e8\u05d5\u05e1"
     ],
+    "name:hin_x_preferred":[
+        "\u0938\u0948\u0902\u091f \u092a\u0940\u091f\u0930"
+    ],
     "name:hrv_x_preferred":[
         "Petar"
+    ],
+    "name:hsb_x_preferred":[
+        "Syman P\u011btr"
     ],
     "name:hun_x_preferred":[
         "P\u00e9ter apostol"
     ],
     "name:hye_x_preferred":[
         "\u054a\u0565\u057f\u0580\u0578\u057d \u0561\u057c\u0561\u0584\u0575\u0561\u056c"
+    ],
+    "name:hyw_x_preferred":[
+        "\u054a\u0565\u057f\u0580\u0578\u057d \u0561\u057c\u0561\u0584\u0565\u0561\u056c"
     ],
     "name:ido_x_preferred":[
         "Santo Petrus"
@@ -192,6 +219,9 @@
     "name:ita_x_preferred":[
         "Pietro apostolo"
     ],
+    "name:ita_x_variant":[
+        "Pietro"
+    ],
     "name:jav_x_preferred":[
         "Simon Petrus"
     ],
@@ -200,6 +230,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10ec\u10db\u10d8\u10dc\u10d3\u10d0 \u10de\u10d4\u10e2\u10e0\u10d4"
+    ],
+    "name:kat_x_variant":[
+        "\u10de\u10d4\u10e2\u10e0\u10d4"
     ],
     "name:kom_x_preferred":[
         "\u041f\u0435\u0442\u044b\u0440 \u043b\u0443\u043d"
@@ -225,8 +258,14 @@
     "name:lit_x_preferred":[
         "Apa\u0161talas Petras"
     ],
+    "name:lld_x_preferred":[
+        "Apostul Pire"
+    ],
     "name:lmo_x_preferred":[
         "San Peder"
+    ],
+    "name:ltz_x_preferred":[
+        "Simon Petrus"
     ],
     "name:mal_x_preferred":[
         "\u0d2a\u0d24\u0d4d\u0d30\u0d4b\u0d38\u0d4d \u0d36\u0d4d\u0d32\u0d40\u0d39\u0d3e"
@@ -239,6 +278,9 @@
     ],
     "name:mlg_x_preferred":[
         "Petera"
+    ],
+    "name:mlt_x_preferred":[
+        "Pietru"
     ],
     "name:mon_x_preferred":[
         "\u0413\u044d\u0433\u044d\u044d\u043d \u041f\u0435\u0442\u0440"
@@ -279,6 +321,9 @@
     "name:pms_x_preferred":[
         "Simon-Pero"
     ],
+    "name:pnb_x_preferred":[
+        "\u067e\u0637\u0631\u0633"
+    ],
     "name:pol_x_preferred":[
         "Piotr Aposto\u0142"
     ],
@@ -315,8 +360,14 @@
     "name:slv_x_preferred":[
         "Sveti Peter"
     ],
+    "name:slv_x_variant":[
+        "sveti Peter"
+    ],
     "name:spa_x_preferred":[
         "Sim\u00f3n Pedro"
+    ],
+    "name:spa_x_variant":[
+        "Pedro"
     ],
     "name:sqi_x_preferred":[
         "Sh\u00ebn Pjetri"
@@ -360,8 +411,14 @@
     "name:urd_x_preferred":[
         "\u067e\u0637\u0631\u0633"
     ],
+    "name:uzb_x_preferred":[
+        "Avliyo Pyotr"
+    ],
     "name:vec_x_preferred":[
         "San Piero"
+    ],
+    "name:vec_x_variant":[
+        "San Pi\u00e8ro"
     ],
     "name:vie_x_preferred":[
         "Saint Peter"
@@ -515,7 +572,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494438,
+    "wof:lastmodified":1690846213,
     "wof:name":"Saint Peter",
     "wof:parent_id":85632677,
     "wof:placetype":"region",

--- a/data/890/420/185/890420185.geojson
+++ b/data/890/420/185/890420185.geojson
@@ -25,6 +25,9 @@
     "name:msa_x_preferred":[
         "Kampung Portugis"
     ],
+    "name:por_x_preferred":[
+        "Portuguese Settlement"
+    ],
     "name:und_x_variant":[
         "Saint John's"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890420185,
-    "wof:lastmodified":1566612040,
+    "wof:lastmodified":1690846214,
     "wof:name":"Saint John's Village",
     "wof:parent_id":85674921,
     "wof:placetype":"locality",

--- a/data/890/420/187/890420187.geojson
+++ b/data/890/420/187/890420187.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0644\u0639\u0628\u0629 \u062c\u064a\u0631\u0627\u0644\u062f"
+    ],
     "name:deu_x_preferred":[
         "Das Spiel"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:fra_x_preferred":[
         "Jessie"
+    ],
+    "name:gle_x_preferred":[
+        "Gerald's Game"
     ],
     "name:hun_x_preferred":[
         "Bilincsben"
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":890420187,
-    "wof:lastmodified":1566612040,
+    "wof:lastmodified":1690846213,
     "wof:name":"Gerald's",
     "wof:parent_id":85674921,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.