### PR TITLE
ms concordances, placetype local, and more

### DIFF
--- a/data/856/749/11/85674911.geojson
+++ b/data/856/749/11/85674911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004274,
-    "geom:area_square_m":50620246.798646,
+    "geom:area_square_m":50620402.626021,
     "geom:bbox":"-62.230133,16.67536,-62.140533,16.747808",
     "geom:latitude":16.709321,
     "geom:longitude":-62.188078,
@@ -207,11 +207,13 @@
         "gn:id":3578045,
         "gp:id":20069826,
         "hasc:id":"MS.SA",
+        "iso:code":"MS-A",
         "iso:id":"MS-A",
         "qs_pg:id":1083236
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MS",
-    "wof:geomhash":"496821164a09eb7e7b24d52ced1ec80d",
+    "wof:geomhash":"685606140707b95b6e0faad24b3718b6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -228,7 +230,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494437,
+    "wof:lastmodified":1695884763,
     "wof:name":"Saint Anthony",
     "wof:parent_id":85632677,
     "wof:placetype":"region",

--- a/data/856/749/17/85674917.geojson
+++ b/data/856/749/17/85674917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001459,
-    "geom:area_square_m":17278270.189721,
+    "geom:area_square_m":17278140.025003,
     "geom:bbox":"-62.188632,16.720364,-62.147369,16.777004",
     "geom:latitude":16.745522,
     "geom:longitude":-62.167175,
@@ -195,11 +195,13 @@
         "gn:id":3578044,
         "gp:id":20069827,
         "hasc:id":"MS.SG",
+        "iso:code":"MS-G",
         "iso:id":"MS-G",
         "qs_pg:id":1083252
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MS",
-    "wof:geomhash":"b97f54c9bb12cb94d61def06f0aee63d",
+    "wof:geomhash":"1fb80277e098a4b46f7446b1f9b7b43d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -216,7 +218,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494438,
+    "wof:lastmodified":1695884763,
     "wof:name":"Saint Georges",
     "wof:parent_id":85632677,
     "wof:placetype":"region",

--- a/data/856/749/21/85674921.geojson
+++ b/data/856/749/21/85674921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002707,
-    "geom:area_square_m":32041764.952638,
+    "geom:area_square_m":32041740.690684,
     "geom:bbox":"-62.225458,16.738967,-62.170033,16.819322",
     "geom:latitude":16.77775,
     "geom:longitude":-62.197229,
@@ -550,12 +550,14 @@
         "gn:id":3578039,
         "gp:id":20069828,
         "hasc:id":"MS.SP",
+        "iso:code":"MS-P",
         "iso:id":"MS-P",
         "qs_pg:id":1083392,
         "wd:id":"Q33923"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MS",
-    "wof:geomhash":"de1f5338f013065dd3d22be1579a4494",
+    "wof:geomhash":"0d4f34c32bd58d31716263417dea77a4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -572,7 +574,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690846213,
+    "wof:lastmodified":1695884763,
     "wof:name":"Saint Peter",
     "wof:parent_id":85632677,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.